### PR TITLE
Replace host with hostname for better switch match

### DIFF
--- a/vhost/app.js
+++ b/vhost/app.js
@@ -30,7 +30,7 @@ app.use(function *(next) {
 // composed middleware with the appropriate context.
 
 app.use(function *(next) {
-  switch (this.host) {
+  switch (this.hostname) {
     case 'example.com':
     case 'www.example.com':
       // displays `Hello from main app`


### PR DESCRIPTION
I've copied over the example for using vhosts, but was confused for a second when I found out that this.host includes the port. It's maybe a better example in combination with the switch if you just use the hostname. 
