### PR TITLE
test for 404 - no correct 404 page for exceptions in downstream middleware

### DIFF
--- a/404/app.js
+++ b/404/app.js
@@ -27,4 +27,20 @@ app.use(function *pageNotFound(next){
   }
 })
 
+app.use(function *exception(next){
+  if (this.url != '/exception') {
+    return yield next;
+  }
+
+  this.assert(false, 404);
+})
+
+app.use(function *ok(next){
+  if (this.url != '/ok') {
+    return yield next;
+  }
+
+  this.body = 'ok';
+})
+
 if (!module.parent) app.listen(3000);

--- a/404/test.js
+++ b/404/test.js
@@ -11,4 +11,20 @@ describe('404', function(){
       .expect(/Page Not Found/, done);
     })
   })
+  describe('when GET /exception', function(){
+    it('should return the 404 page', function(done){
+      request
+      .get('/exception')
+      .expect(404)
+      .expect(/Page Not Found/, done);
+    })
+  })
+  describe('when GET /ok', function(){
+    it('should 200 with "ok" message', function(done){
+      request
+      .get('/ok')
+      .expect(200)
+      .expect(/ok/, done);
+  	})
+  })
 })


### PR DESCRIPTION
This test is currently broken, example fix needed.