### PR TITLE
Fix basic-auth example doesn't prompt form to login

### DIFF
--- a/base-auth/app.js
+++ b/base-auth/app.js
@@ -10,6 +10,7 @@ app.use(function* (next){
   } catch (err) {
     if (401 == err.status) {
       this.status = 401;
+      this.set('WWW-Authenticate', 'Basic');
       this.body = 'cant haz that';
     } else {
       throw err;


### PR DESCRIPTION
Originally, the login form doesn't show.
Fix #76 