### PR TITLE
Correct way to call yield next

### DIFF
--- a/base-auth/app.js
+++ b/base-auth/app.js
@@ -6,7 +6,7 @@ var app = module.exports = koa();
 
 app.use(function* (next){
   try {
-    yield* next;
+    yield next;
   } catch (err) {
     if (401 == err.status) {
       this.status = 401;


### PR DESCRIPTION
`yield* next` -> `yield next`

I think when they wrote example, they did it by accident.

The following lines are from [jongleberry](https://github.com/jonathanong)'s article
[yield next vs. yield* next](http://www.jongleberry.com/delegating-yield.html)
>Although we Koa uses it internally for "free" performance, 
>**we don't advocate it to avoid confusion.**

Also [wiki](https://github.com/koajs/koa/wiki/Error-Handling) mentioned it on error handling.
