### PR TITLE
Fix mocha version and unit tests

### DIFF
--- a/404/test.js
+++ b/404/test.js
@@ -1,14 +1,18 @@
-
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('404', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('when GET /', function() {
     it('should return the 404 page', function(done) {
       request
-      .get('/')
-      .expect(404)
-      .expect(/Page Not Found/, done);
+        .get('/')
+        .expect(404)
+        .expect(/Page Not Found/, done);
     });
   });
 });

--- a/base-auth/test.js
+++ b/base-auth/test.js
@@ -1,7 +1,12 @@
-var app = require('./app');
-var request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Koa Basic Auth', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('with no credentials', function() {
     it('should `throw` 401', function(done) {
       request

--- a/blog/test.js
+++ b/blog/test.js
@@ -1,8 +1,13 @@
-const app = require('./app');
-const request = require('supertest').agent(app.listen());
 require('should');
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Blog', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('GET /', function() {
     it('should see title "Posts"', function(done) {
       request

--- a/body-parsing/test.js
+++ b/body-parsing/test.js
@@ -1,7 +1,12 @@
-var app = require('./app');
-var request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Body Parsing', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('POST /uppercase', function() {
     describe('with JSON', function() {
       it('should work', function(done) {

--- a/compose/test.js
+++ b/compose/test.js
@@ -1,7 +1,12 @@
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Compose', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('when GET /', function() {
     it('should say "Hello World"', function(done) {
       request

--- a/cookies/test.js
+++ b/cookies/test.js
@@ -1,7 +1,12 @@
-var app = require('./app');
-var request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Cookies Views', function() {
+  after(function() {
+    server.close();
+  });
+
   [1, 2, 3].forEach(function(i) {
     describe('on iteration #' + i, function() {
       it('should set the views as a cookie and as the body', function(done) {

--- a/csrf/test.js
+++ b/csrf/test.js
@@ -1,11 +1,16 @@
 require('should');
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 let token;
 let cookie;
 
 describe('csrf', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('GET /token', function() {
     it('should get token', function(done) {
       request

--- a/errors/test.js
+++ b/errors/test.js
@@ -1,8 +1,13 @@
 require('should');
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Errors', function() {
+  after(function() {
+    server.close();
+  });
+
   it('should catch the error', function(done) {
     request
     .get('/')

--- a/flash-messages/test.js
+++ b/flash-messages/test.js
@@ -1,8 +1,13 @@
 require('should');
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Flash Messages', function() {
+  after(function() {
+    server.close();
+  });
+
   it('GET should return an empty array', function(done) {
     request
     .get('/messages')

--- a/hello-world/test.js
+++ b/hello-world/test.js
@@ -1,7 +1,12 @@
-var app = require('./app');
-var request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Hello World', function() {
+  after(function() {
+    server.close();
+  });
+
   it('should say "Hello World"', function(done) {
     request
     .get('/')

--- a/multipart/test.js
+++ b/multipart/test.js
@@ -1,7 +1,8 @@
 require('should');
-const app = require('./app');
 const fs = require('fs');
-const request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 // https://github.com/mscdex/busboy/blob/master/test/test-types-multipart.js
 const ct = 'multipart/form-data; boundary=---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k';
@@ -28,6 +29,10 @@ const body = [
 ].join('\r\n');
 
 describe('Multipart Files', function() {
+  after(function() {
+    server.close();
+  });
+
   it('should store all the files', function(done) {
     request
     .post('/')

--- a/negotiation/test.js
+++ b/negotiation/test.js
@@ -1,7 +1,12 @@
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('negotiation', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('json', function() {
     it('should respond with json', function(done) {
       request

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-config-standard": "^6.2.0",
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1",
-    "mocha": "*",
+    "mocha": "^5.0.0",
     "should": "^3.3.2",
     "supertest": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "koa-static": "^3.0.0",
     "koa-views": "^6.0.2",
     "streaming-json-stringify": "^3.1.0",
-    "supertest": "^3.0.0",
     "swig": "^1.4.2"
   },
   "devDependencies": {
@@ -28,7 +27,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "mocha": "*",
     "should": "^3.3.2",
-    "supertest": "*"
+    "supertest": "^3.0.0"
   },
   "scripts": {
     "test": "make test"

--- a/stream-file/test.js
+++ b/stream-file/test.js
@@ -1,7 +1,12 @@
-var app = require('./app');
-var request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Stream File', function() {
+  after(function() {
+    server.close();
+  });
+
   it('GET /app.js', function(done) {
     request
     .get('/app.js')

--- a/stream-objects/test.js
+++ b/stream-objects/test.js
@@ -1,8 +1,13 @@
 require('should');
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Stream Objects', function() {
+  after(function() {
+    server.close();
+  });
+
   it('GET /', function(done) {
     request
     .get('/app.js')

--- a/stream-view/test.js
+++ b/stream-view/test.js
@@ -1,8 +1,13 @@
 require('should');
 const app = require('./app');
-const request = require('supertest').agent(app.listen());
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Stream View', function() {
+  after(function() {
+    server.close();
+  });
+
   it('GET /', function(done) {
     request
     .get('/')

--- a/templates/test.js
+++ b/templates/test.js
@@ -1,7 +1,12 @@
-var app = require('./app');
-var request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Templates', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('GET /', function() {
     it('should respond with a rendered view', function(done) {
       request

--- a/vhost/test.js
+++ b/vhost/test.js
@@ -1,7 +1,12 @@
-var app = require('./app');
-var request = require('supertest').agent(app.listen());
+const app = require('./app');
+const server = app.listen();
+const request = require('supertest').agent(server);
 
 describe('Virtual Host', function() {
+  after(function() {
+    server.close();
+  });
+
   describe('www subdomain koa app', function() {
     describe('when GET /', function() {
       it('should say "Hello from www app"', function(done) {


### PR DESCRIPTION
As mentioned in comment https://github.com/koajs/examples/pull/114#issuecomment-359583756, builds are failing due to --no-exit default flag since mocha 4.0.0

To fix this issue, I did the following changes :

* removed supertest duplicate dependency
* fixed mocha version
* updated all test files to empty event loop after running test (the koa app instance were still running)