### PR TITLE
fixes inline-style link with title

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ make lint
  - [koa2-boilerplate](https://github.com/geekplux/koa2-boilerplate) - A minimal boilerplate of koa v2 development
  - [api-boilerplate](https://github.com/koajs/api-boilerplate) - API application boilerplate
  - [component-koa-et-al-boilerplate](https://github.com/sunewt/component-koa-et-al-boilerplate) - Server/client boilerplate with component, livereload, and more
- - [koa-typescript-starter] (https://github.com/ddimaria/koa-typescript-starter) - A Koa2 starter kit using TypeScript, ES6 imports/exports, Travis, Coveralls, Jasmine, Chai, Istanbul/NYC, Lodash, Nodemon, Docker, & Swagger
+ - [koa-typescript-starter](https://github.com/ddimaria/koa-typescript-starter) - A Koa2 starter kit using TypeScript, ES6 imports/exports, Travis, Coveralls, Jasmine, Chai, Istanbul/NYC, Lodash, Nodemon, Docker, & Swagger
 
 ## Yeoman Generators
  - [koa-rest](https://github.com/PatrickWolleb/generator-koa-rest) - RESTful API scaffolder with subgenerator


### PR DESCRIPTION
Remove unnecessary space(" ") to show hyperlink, as intended.