### PR TITLE
Update to koa-body's latest syntax to access files in multipart example

### DIFF
--- a/multipart/app.js
+++ b/multipart/app.js
@@ -22,7 +22,7 @@ app.use(async function(ctx) {
   // make the temporary directory
   await fs.mkdir(tmpdir);
   const filePaths = [];
-  const files = ctx.request.body.files || {};
+  const files = ctx.request.files || {};
 
   for (let key in files) {
     const file = files[key];


### PR DESCRIPTION
This PR fix where koa-body stores the files in latest version on the `ctx`.