### PR TITLE
fix broken markdown link in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ make lint
  - [koa2-boilerplate](https://github.com/geekplux/koa2-boilerplate) - A minimal boilerplate of koa v2 development
  - [api-boilerplate](https://github.com/koajs/api-boilerplate) - API application boilerplate
  - [component-koa-et-al-boilerplate](https://github.com/sunewt/component-koa-et-al-boilerplate) - Server/client boilerplate with component, livereload, and more
- - [koa-typescript-starter] (https://github.com/ddimaria/koa-typescript-starter) - A Koa2 starter kit using TypeScript, ES6 imports/exports, Travis, Coveralls, Jasmine, Chai, Istanbul/NYC, Lodash, Nodemon, Docker, & Swagger
+ - [koa-typescript-starter](https://github.com/ddimaria/koa-typescript-starter) - A Koa2 starter kit using TypeScript, ES6 imports/exports, Travis, Coveralls, Jasmine, Chai, Istanbul/NYC, Lodash, Nodemon, Docker, & Swagger
 
 ## Yeoman Generators
  - [koa-rest](https://github.com/PatrickWolleb/generator-koa-rest) - RESTful API scaffolder with subgenerator


### PR DESCRIPTION
<img width="598" alt="screen shot 2019-01-27 at 5 12 47 pm" src="https://user-images.githubusercontent.com/6374832/51809590-e79f0100-2256-11e9-8e13-53cae46e9e74.png">
