### PR TITLE
[koa-session] security example for app.keys

### DIFF
--- a/csrf/app.js
+++ b/csrf/app.js
@@ -3,6 +3,7 @@ const koaBody = require('koa-body');
 const session = require('koa-session');
 const CSRF = require('koa-csrf');
 const router = require('koa-router')();
+const Keygrip = require('keygrip');
 
 const app = module.exports = new Koa();
 
@@ -10,7 +11,7 @@ const app = module.exports = new Koa();
  * csrf need session
  */
 
-app.keys = ['session key', 'csrf example'];
+app.keys = new Keygrip(['insert 64 bytes random string', 'insert another 64 bytes random string'], 'sha512');
 app.use(session(app));
 app.use(koaBody());
 

--- a/flash-messages/app.js
+++ b/flash-messages/app.js
@@ -6,11 +6,12 @@
 const Koa = require('koa');
 const rawBody = require('raw-body');
 const session = require('koa-session');
+const Keygrip = require('keygrip');
 
 const app = module.exports = new Koa();
 
 // required for signed cookie sessions
-app.keys = ['key1', 'key2'];
+app.keys = new Keygrip(['insert 64 bytes random string', 'insert another 64 bytes random string'], 'sha512');
 app.use(session(app));
 
 app.use(async function(ctx, next) {


### PR DESCRIPTION
**Documentation**:
  - Add a security example for app.keys by redefining Keygrip to use sha512 instead of default sha1 for  `cors` and `flash-messages` examples
