### PR TITLE
Replace fs-promise with built-in fs/promises module

### DIFF
--- a/multipart/app.js
+++ b/multipart/app.js
@@ -6,9 +6,9 @@
  */
 
 const os = require('os');
+const fs = require('fs');
 const path = require('path');
 const Koa = require('koa');
-const fs = require('fs-promise');
 const koaBody = require('koa-body');
 
 const app = module.exports = new Koa();
@@ -20,7 +20,7 @@ app.use(async function(ctx) {
   const tmpdir = path.join(os.tmpdir(), uid());
 
   // make the temporary directory
-  await fs.mkdir(tmpdir);
+  await fs.promises.mkdir(tmpdir);
   const filePaths = [];
   const files = ctx.request.files || {};
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "bugs": "https://github.com/koajs/examples/issues",
   "dependencies": {
     "ejs": "^2.5.6",
-    "fs-promise": "^2.0.3",
     "koa": "^2.2.0",
     "koa-basic-auth": "^2.0.0",
     "koa-body": "^4.0.8",


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

## Description

[fs-promise](https://www.npmjs.com/package/fs-promise) is deprecated and since Node v10.X, there is a built-in `fs/promises` module (also available with the `.promises` property) for promise-based file system APIs.

This removes `fs-promise` and uses the built-in module that is available.

- Closes #147 (spam)