### PR TITLE
Upgrade ESLint and configs/plugins to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
     "swig-templates": "^2.0.3"
   },
   "devDependencies": {
-    "eslint": "^3.8.1",
+    "eslint": "^8.51.0",
     "eslint-config-koa": "^2.0.2",
-    "eslint-config-standard": "^6.2.0",
-    "eslint-plugin-promise": "^3.3.0",
-    "eslint-plugin-standard": "^2.0.1",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-promise": "^6.1.1",
     "mocha": "^5.0.0",
     "should": "^3.3.2",
     "supertest": "^3.0.0"


### PR DESCRIPTION
## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [x] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [x] I have ensured that my code changes pass linting tests.
- [x] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.

## Description

ESLint versions are ancient and I get warnings when running on current 18.X LTS series.

```console
$ npm run lint

> koa-examples@0.0.1 lint
> eslint .

(node:506347) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
(node:506347) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
(node:506347) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
(node:506347) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
(node:506347) Warning: Accessing non-existent property 'dirs' of module exports inside circular dependency
(node:506347) Warning: Accessing non-existent property 'pushd' of module exports inside circular dependency
(node:506347) Warning: Accessing non-existent property 'popd' of module exports inside circular dependency
```

This all ESLint dependencies. ESLint [8](https://eslint.org/docs/latest/use/migrate-to-8.0.0) supports v16 and above. `eslint-plugin-standard` is no longer needed too.